### PR TITLE
Added ODT export functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Adds a search bar to perform a fulltext search
 Lists all contacts.
 
 
-  * ``[ADRESSSBOOK:index?departments]`` - Separate List by departments
+  * ``[ADRESSBOOK:index?departments]`` - Separate List by departments
 
 ![](screenshots/addnew.png)
 


### PR DESCRIPTION
Added ODT export functionality for [ADDRESSBOOK:print]. This generates a table of addresses within a ODT generated using the [ODT plugin](https://www.dokuwiki.org/plugin:odt). Does only work on pages where printable list is generated via "[ADDRESSBOOK:print]".

(Replaces my previous pull request, which contained commits that were not intended within that pull request.)