### PR TITLE
Acl permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Creates a printable list
 
 Contact search results are display on the search results page. In order to activate links to show or edit a contact, a page id must be stated, to which the link directs. This target page must contatin an ``[ADDRESSBOOK:]``-Tag for the request to performed.
 
+### Option 'use ACL permissions'
+
+Required access level ([ACL](https://www.dokuwiki.org/acl#background_info)) to edit the addressbook. The value 'no' uses the classic check: access via the setting of 'ismanager' in [$INFO](https://www.dokuwiki.org/devel:environment#info).
 
 ## Issues / Ideas
 

--- a/conf/default.php
+++ b/conf/default.php
@@ -1,3 +1,3 @@
 <?php
 $conf['search link target'] = '';
-
+$conf['use ACL permissions'] = 'no';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,2 +1,3 @@
 <?php
 $meta['search link target'] = array('string');
+$meta['use ACL permissions'] = array('multichoice', '_choices' => array('no','AUTH_NONE','AUTH_READ','AUTH_EDIT','AUTH_CREATE','AUTH_UPLOAD','AUTH_DELETE','AUTH_ADMIN'));

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -1,2 +1,3 @@
 <?php
 $lang['search link target'] = "Ziel-Seite (id) für links im Bereich der Suchergebnisse. Diese muss einen [ADDRESSBOOK:]-Tag enthalten, damit der Auftrag verarbeitet werden kann";
+$lang['use ACL permissions'] = "Benötigtes Zugriffslevel zum Bearbeiten des Adressbuchs. Beim Wert 'no' wird das klassische Zugriffsrecht angewandt: die Prüfung auf den Eigenschaftswert von 'ismanager' in \$INFO.";

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -1,2 +1,3 @@
 <?php
 $lang['search link target'] = "Target id for links on the search page. The target page must contain an [ADDRESSSBOOK:]-Tag";
+$lang['use ACL permissions'] = "Required access level (ACL) to edit the addressbook. The value 'no' uses the classic check: access via the setting of 'ismanager' in \$INFO.";

--- a/syntax.php
+++ b/syntax.php
@@ -36,7 +36,10 @@ class syntax_plugin_addressbook extends DokuWiki_Syntax_Plugin {
     
     function __construct(){
         global $INFO;
-        if ($INFO['ismanager'] === true) $this->editor = true;
+        $permissionlevel = auth_quickaclcheck($data['name']);
+        if ($permissionlevel >= AUTH_EDIT) {
+            $this->editor = true;
+        }
         if (isset($INFO['userinfo'])) $this->loggedin = true;
     }
 

--- a/syntax.php
+++ b/syntax.php
@@ -36,9 +36,47 @@ class syntax_plugin_addressbook extends DokuWiki_Syntax_Plugin {
     
     function __construct(){
         global $INFO;
+        
         $permissionlevel = auth_quickaclcheck($data['name']);
-        if ($permissionlevel >= AUTH_EDIT) {
-            $this->editor = true;
+        switch ($this->getConf('use ACL permissions')) {
+            case 'no':
+                if ($INFO['ismanager'] === true) $this->editor = true;
+                break;
+            case 'AUTH_NONE':
+                if ($permissionlevel >= AUTH_NONE) {
+                    $this->editor = true;
+                }
+                break;
+            case 'AUTH_READ':
+                if ($permissionlevel >= AUTH_READ) {
+                    $this->editor = true;
+                }
+                break;
+            case 'AUTH_EDIT':
+                if ($permissionlevel >= AUTH_EDIT) {
+                    $this->editor = true;
+                }
+                break;
+            case 'AUTH_CREATE':
+                if ($permissionlevel >= AUTH_CREATE) {
+                    $this->editor = true;
+                }
+                break;
+            case 'AUTH_UPLOAD':
+                if ($permissionlevel >= AUTH_UPLOAD) {
+                    $this->editor = true;
+                }
+                break;
+            case 'AUTH_DELETE':
+                if ($permissionlevel >= AUTH_DELETE) {
+                    $this->editor = true;
+                }
+                break;
+            case 'AUTH_ADMIN':
+                if ($permissionlevel >= AUTH_ADMIN) {
+                    $this->editor = true;
+                }
+                break;  
         }
         if (isset($INFO['userinfo'])) $this->loggedin = true;
     }


### PR DESCRIPTION
Permission was checked in the previous version, but only if the user has "manager" rights (see 'ismanager' [here](https://www.dokuwiki.org/devel:environment?s[]=ismanager)).

This Pull Request adds a configuration setting named 'use ACL permissions' to enable ACL checks. You can define the required access level (the level decides whether the edit fields will be added, or not). Using the value 'no' will use the previous ('classic') behavior.

fixes #1 